### PR TITLE
filter innermost volume should start from that trade day

### DIFF
--- a/app/sqls/filter.sql
+++ b/app/sqls/filter.sql
@@ -72,6 +72,7 @@ LEFT JOIN LATERAL
                         SELECT volume AS volume
                         FROM stock_daily
                         WHERE code = sf.code
+                        AND trade_day <= sf.trade_day
                         ORDER BY trade_day DESC
                         LIMIT 5
                 ) AS innermost

--- a/app/utils/filter.py
+++ b/app/utils/filter.py
@@ -61,7 +61,10 @@ def build_stmt_postgresql(trade_day: date) -> Select:
 
     innermost = (
         select(StockDaily.volume)
-            .where(StockDaily.code == static_filtering_cte.c.code)
+            .where(and_(
+                StockDaily.code == static_filtering_cte.c.code,
+                StockDaily.trade_day <= static_filtering_cte.c.trade_day
+            ))
             .order_by(StockDaily.trade_day.desc())
             .correlate(static_filtering_cte)
             .limit(5)


### PR DESCRIPTION
A condition was missing that causes ma5 volume to perform on the latest trade_day instead of the specified.